### PR TITLE
Add the ability to pass through the "loopback" flag.

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ Adapter.prototype.broadcast = function(packet, opts){
   var flags = opts.flags || {};
   var packetOpts = {
     preEncoded: true,
+    loopback: flags.loopback,
     volatile: flags.volatile,
     compress: flags.compress
   };


### PR DESCRIPTION
This works together with a change in socket.io, adding the "loopback"
flag to Namespace to allow messages to be emitted on the local
endpoint.